### PR TITLE
Feature/potato 29 fix taskcreate modal

### DIFF
--- a/src/components/TaskEditor.tsx
+++ b/src/components/TaskEditor.tsx
@@ -180,6 +180,9 @@ export default function TaskEditor(props: Props) {
 
   useEffect(() => {
     resetErrorText();
+    if (props.isVisible === true) {
+      setTaskName("");
+    }
   }, [props.isVisible]);
 
   const option = (useOption: boolean) => {


### PR DESCRIPTION
タスク作成モーダルが表示されたときにフォームの内容を初期化するように修正